### PR TITLE
Read the private and public key from outside your project

### DIFF
--- a/bunqPayRequest.php
+++ b/bunqPayRequest.php
@@ -10,12 +10,10 @@ const BUNQ_API_VERSION = 'v1';
 $API_KEY = 'Your bunq API-key';
 
 //Your RSA keys used for installation
-$clientPublicKey = "-----BEGIN PUBLIC KEY-----
-Your Public key
------END PUBLIC KEY-----";
-$clientPrivateKey = "-----BEGIN RSA PRIVATE KEY-----
-Your private key
------END RSA PRIVATE KEY-----";
+//Try to avoid having your keys in your project and/or repository.
+//Store the keys seperately on your server if possible.
+$clientPublicKey = file_get_contents("/var/keys/client.pub");
+$clientPrivateKey = file_get_contents("/var/keys/client.key");
 
 $createUuid = uniqid();
 $bunqUserId = '';


### PR DESCRIPTION
If keys are stored in the project files it often end up (by mistake) in version control (like Git). To avoid the risk that people end up uploading their keys to a (public) hosted version control (like Github) it is good to have an example which let people store their keys by default.
If you put the key in there code it will be their responsibility but as an public piece of proof-of-concept at least you set the right example!

N.B. I haven't written any PHP in the last 3 years so my implementation of reading from a file might be outdated, but for a more security-aware internet I found it my responsibility to at least come up with this PR 😃 